### PR TITLE
TASK-53847 Avoid display Sign Up link when registration is not allowed

### DIFF
--- a/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/web/filter/MetamaskRegistrationFilter.java
+++ b/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/web/filter/MetamaskRegistrationFilter.java
@@ -114,7 +114,8 @@ public class MetamaskRegistrationFilter extends JspBasedWebHandler implements Fi
       // If user is already authenticated, no registration form is required
       if (request.getRemoteUser() == null
           && StringUtils.isNotBlank(walletAddress)
-          && metamaskLoginService.isAllowUserRegistration(walletAddress)) {
+          && (metamaskLoginService.isSuperUser(walletAddress)
+              || metamaskLoginService.isAllowUserRegistration(walletAddress))) {
 
         if (StringUtils.startsWith(password, METAMASK_SIGNED_MESSAGE_PREFIX)) {
           // Step 1: Forward to user registration form. The user isn't found and


### PR DESCRIPTION
Prior to this change, when DEED NFT owner didn't signed up yet, the 'Create Free account' link is displayed in Login page until he/she signs up. This modification will avoid to display it knowing that DEED owner will be able to sign up when clicking on 'Sign in with Metamask'.