### PR TITLE
BUILDERS-197: send initial funds for Metamask wallets first login

### DIFF
--- a/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListenerTest.java
+++ b/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListenerTest.java
@@ -24,6 +24,7 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.wallet.model.Wallet;
 import org.exoplatform.wallet.model.WalletProvider;
 import org.exoplatform.wallet.service.WalletAccountService;
+import org.exoplatform.wallet.utils.WalletUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -70,9 +71,12 @@ public class NewMetamaskCreatedUserListenerTest {
     when(walletAccountService.createWalletInstance(WalletProvider.METAMASK,
             username,
             1l)).thenReturn(wallet);
+    when(walletAccountService.saveWallet(any(Wallet.class), anyBoolean())).thenAnswer(invocation -> invocation.getArgument(0, Wallet.class));
     when(identityManager.getOrCreateUserIdentity(username)).thenReturn(userIdentity);
+    doNothing().when(listenerService).broadcast(anyString(), any(), any());
 
     listener.postSave(user, true);
     verify(walletAccountService, times(1)).saveWallet(any(Wallet.class), anyBoolean());
+    verify(listenerService, times(1)).broadcast(eq(WalletUtils.NEW_ADDRESS_ASSOCIATED_EVENT), any(Wallet.class), eq(username));
   }
 }

--- a/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListenerTest.java
+++ b/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListenerTest.java
@@ -16,6 +16,7 @@
  */
 package io.meeds.tenant.metamask.listener;
 
+import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.impl.UserImpl;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -40,10 +41,13 @@ public class NewMetamaskCreatedUserListenerTest {
   @Mock
   WalletAccountService walletAccountService;
 
+  @Mock
+  ListenerService listenerService;
+
   @Test
-  public void testNewMetamaskCreatedUserListener() throws IllegalAccessException {
+  public void testNewMetamaskCreatedUserListener() throws Exception {
     String username = "0x8714924ADEdB61b790d639F19c3D6F0FE2Cb7576";
-    NewMetamaskCreatedUserListener listener = new NewMetamaskCreatedUserListener(identityManager, walletAccountService);
+    NewMetamaskCreatedUserListener listener = new NewMetamaskCreatedUserListener(identityManager, walletAccountService, listenerService);
 
     User user = new UserImpl("not an address");
     listener.postSave(user, true);

--- a/deeds-tenant-service/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/deeds-tenant-service/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Prior to this change when the wallet is created after Metamask wallet is created no initial founds in sent
This change allows sending initial funds  after the creation of a wallet with the selected wallet from signs