### PR TITLE
TASK-150: create wallet after sign in with metamask (#5)

### DIFF
--- a/deeds-tenant-service/pom.xml
+++ b/deeds-tenant-service/pom.xml
@@ -81,5 +81,15 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.exoplatform.addons.wallet</groupId>
+      <artifactId>wallet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.social</groupId>
+      <artifactId>social-component-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListener.java
+++ b/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListener.java
@@ -1,0 +1,72 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.tenant.metamask.listener;
+
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserEventListener;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.wallet.model.Wallet;
+import org.exoplatform.wallet.model.WalletProvider;
+import org.exoplatform.wallet.service.WalletAccountService;
+import org.web3j.crypto.WalletUtils;
+
+public class NewMetamaskCreatedUserListener extends UserEventListener {
+
+  private static final Log     LOG = ExoLogger.getLogger(NewMetamaskCreatedUserListener.class);
+
+  private IdentityManager      identityManager;
+
+  private WalletAccountService walletAccountService;
+
+  public NewMetamaskCreatedUserListener(IdentityManager identityManager, WalletAccountService walletAccountService) {
+    this.walletAccountService = walletAccountService;
+    this.identityManager = identityManager;
+  }
+
+  @Override
+  public void postSave(User user, boolean isNew) {
+    String address = user.getUserName();
+    if (!isNew || !user.isEnabled() || !WalletUtils.isValidAddress(address)) {
+      return;
+    }
+    Wallet wallet = walletAccountService.getWalletByAddress(address);
+    if (wallet != null) {
+      LOG.info("Wallet with address {} is already associated to identity id {}."
+          + "The used Metamask address will not be associated to current user account.",
+               address,
+               wallet.getTechnicalId());
+      return;
+    }
+    createUserWalletByAddress(address);
+  }
+
+  private void createUserWalletByAddress(String address) {
+    try {
+      Identity identity = identityManager.getOrCreateUserIdentity(address);
+      Wallet userWallet = walletAccountService.createWalletInstance(WalletProvider.METAMASK,
+                                                                    address,
+                                                                    Long.valueOf(identity.getId()));
+      walletAccountService.saveWallet(userWallet, true);
+    } catch (Exception e) {
+      LOG.warn("Error while associating Metamask wallet for user {}", address, e);
+    }
+  }
+
+}

--- a/deeds-tenant-service/src/main/resources/conf/portal/configuration.xml
+++ b/deeds-tenant-service/src/main/resources/conf/portal/configuration.xml
@@ -96,4 +96,14 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.organization.OrganizationService</target-component>
+    <component-plugin>
+      <name>new.metamask.created.user.listener</name>
+      <set-method>addListenerPlugin</set-method>
+      <type>io.meeds.tenant.metamask.listener.NewMetamaskCreatedUserListener</type>
+      <description>a listener to associate used Metamask wallet to newly registered user</description>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>

--- a/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListenerTest.java
+++ b/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListenerTest.java
@@ -1,0 +1,74 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.tenant.metamask.listener;
+
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.impl.UserImpl;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.wallet.model.Wallet;
+import org.exoplatform.wallet.model.WalletProvider;
+import org.exoplatform.wallet.service.WalletAccountService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NewMetamaskCreatedUserListenerTest {
+
+  @Mock
+  IdentityManager      identityManager;
+
+  @Mock
+  WalletAccountService walletAccountService;
+
+  @Test
+  public void testNewMetamaskCreatedUserListener() throws IllegalAccessException {
+    String username = "0x8714924ADEdB61b790d639F19c3D6F0FE2Cb7576";
+    NewMetamaskCreatedUserListener listener = new NewMetamaskCreatedUserListener(identityManager, walletAccountService);
+
+    User user = new UserImpl("not an address");
+    listener.postSave(user, true);
+    verify(walletAccountService, times(0)).saveWallet(any(Wallet.class), anyBoolean());
+
+    user = new UserImpl(username);
+    listener.postSave(user, false);
+    verify(walletAccountService, times(0)).saveWallet(any(Wallet.class), anyBoolean());
+
+    Wallet wallet = new Wallet();
+    wallet.setAddress(username);
+    Identity userIdentity = new Identity();
+    userIdentity.setId(String.valueOf(1l));
+
+    when(walletAccountService.getWalletByAddress(username)).thenReturn(wallet);
+    listener.postSave(user, true);
+    verify(walletAccountService, times(0)).saveWallet(any(Wallet.class), anyBoolean());
+
+    when(walletAccountService.getWalletByAddress(username)).thenReturn(null);
+    when(walletAccountService.createWalletInstance(WalletProvider.METAMASK,
+            username,
+            1l)).thenReturn(wallet);
+    when(identityManager.getOrCreateUserIdentity(username)).thenReturn(userIdentity);
+
+    listener.postSave(user, true);
+    verify(walletAccountService, times(1)).saveWallet(any(Wallet.class), anyBoolean());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,8 @@
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.social.version>6.3.x-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.wallet.version>2.4.x-SNAPSHOT</org.exoplatform.wallet.version>
     <addon.meeds.deeds-dapp.version>1.0.x-SNAPSHOT</addon.meeds.deeds-dapp.version>
-
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>
     <exo.snapshots.repo.url>https://repository.exoplatform.org/content/repositories/meeds-snapshots</exo.snapshots.repo.url>
@@ -52,16 +51,16 @@
     <dependencies>
       <!-- Import versions from platform project -->
       <dependency>
-        <groupId>org.exoplatform.social</groupId>
-        <artifactId>social</artifactId>
-        <version>${org.exoplatform.social.version}</version>
+        <groupId>io.meeds.deeds-dapp</groupId>
+        <artifactId>deeds-dapp-parent</artifactId>
+        <version>${addon.meeds.deeds-dapp.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>io.meeds.deeds-dapp</groupId>
-        <artifactId>deeds-dapp-parent</artifactId>
-        <version>${addon.meeds.deeds-dapp.version}</version>
+        <groupId>org.exoplatform.addons.wallet</groupId>
+        <artifactId>wallet</artifactId>
+        <version>${org.exoplatform.wallet.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Prior to this change when signing in with metaMask no wallet is created
This change allows the creation of a wallet with the selected wallet from signIn