### PR TITLE
BUILDERS-197: send initial funds for Metamask wallets first login (#6)

### DIFF
--- a/deeds-tenant-service/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/deeds-tenant-service/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Prior to this change when the wallet is created after Metamask wallet is created no initial founds in sent
This change allows sending initial funds after the creation of a wallet with the selected wallet from signs