### PR TITLE
fix: Fix Login Page Style - MEED-1912 - Meeds-io/MIPs#52

### DIFF
--- a/deeds-tenant-webapp/src/main/webapp/WEB-INF/jsp/metamaskSetupForm.jsp
+++ b/deeds-tenant-webapp/src/main/webapp/WEB-INF/jsp/metamaskSetupForm.jsp
@@ -61,12 +61,10 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="theme-color" content="<%=brandingPrimaryColor%>" />
   <!-- Preload Styles & Fonts & Scripts for HTTP/2 optimizations -->
-  <link rel="preload" href="/eXoSkin/skin/fonts/vuetify/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="/eXoSkin/skin/fonts/vuetify/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="/eXoSkin/skin/fonts/vuetify/fa-regular-400.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="/eXoSkin/skin/fonts/vuetify/materialdesignicons-webfont.woff2?v=5.9.55" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="/eXoSkin/skin/fonts/Ionic/ionicons.ttf" as="font" type="font/ttf" crossorigin />
-  <link rel="preload" href="/eXoSkin/skin/fonts/PLF-FONT-ICONS.ttf?-m9uidt" as="font" type="font/ttf" crossorigin />
+  <link rel="preload" href="/platform-ui/skin/fonts/vuetify/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="/platform-ui/skin/fonts/vuetify/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="/platform-ui/skin/fonts/vuetify/fa-regular-400.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="/platform-ui/skin/fonts/vuetify/materialdesignicons-webfont.woff2?v=5.9.55" as="font" type="font/woff2" crossorigin />
   <link rel="preload" as="style" type="text/css" href="<%=brandingThemeUrl%>" />
   <% for(String skinUrl : skinUrls) { %>
   <link rel="preload" href= "<%=skinUrl%>" as="style" type="text/css" />

--- a/deeds-tenant-webapp/src/main/webapp/skin/less/login.less
+++ b/deeds-tenant-webapp/src/main/webapp/skin/less/login.less
@@ -16,8 +16,8 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 */
-@import (css) "/eXoSkin/skin/css/platform/portlets/extensions/login.css";
-@import (css) "/eXoSkin/skin/css/component/ImageCropper/cropper.min.css";
+@import (css) "/social-portlet/skin/css/standalone-pages/Login.css";
+@import (css) "/platform-ui/skin/css/component/ImageCropper/cropper.min.css";
 
 @import "./variables.less";
 


### PR DESCRIPTION
Prior to this change, the login style override wasn't updated to apply change made on Meeds-io/MIPs#52 which changes the context name from eXoSkin to platform-ui. This change will allow to make it work using new style contexts (platform-ui and social-portlet).