### PR TITLE
feat: Enable WoM Integration only when the Deed Tenant is configured

### DIFF
--- a/deeds-tenant-service/src/main/java/io/meeds/tenant/integration/service/TenantServiceFacade.java
+++ b/deeds-tenant-service/src/main/java/io/meeds/tenant/integration/service/TenantServiceFacade.java
@@ -23,4 +23,6 @@ public interface TenantServiceFacade {
 
   boolean isTenantManager(String address, long nftId);
 
+  void initMetaverseIntegration();
+
 }

--- a/deeds-tenant-service/src/main/java/io/meeds/tenant/service/TenantManagerService.java
+++ b/deeds-tenant-service/src/main/java/io/meeds/tenant/service/TenantManagerService.java
@@ -58,6 +58,8 @@ public class TenantManagerService implements Startable {
       DeedTenantHost deedTenantHost = retrieveDeedTenant();
       if (deedTenantHost == null) {
         throw unreadyConfigurationException(null);
+      } else {
+        initMetaverseIntegration();
       }
     }
   }
@@ -114,6 +116,11 @@ public class TenantManagerService implements Startable {
   @SpringIntegration
   private DeedTenantHost retrieveDeedTenant() {// NOSONAR
     return getTenantServiceFacade().getDeedTenant(getNftId());
+  }
+
+  @SpringIntegration
+  private void initMetaverseIntegration() {
+    getTenantServiceFacade().initMetaverseIntegration();
   }
 
   private String getParamValue(InitParams params, String paramName) {

--- a/deeds-tenant-webapp/src/main/java/io/meeds/tenant/DeedTenantApplication.java
+++ b/deeds-tenant-webapp/src/main/java/io/meeds/tenant/DeedTenantApplication.java
@@ -46,6 +46,9 @@ public class DeedTenantApplication extends SpringBootServletInitializer {
     // Avoid creating Deed Tenants Indexes in Deed Tenant Elasticsearch
     // When the ES is misconfigured
     System.setProperty("meeds.elasticsearch.autoCreateIndex", "false");
+    // Disable ListenerService until verifying whether the tenant is included in
+    // WoM or not
+    System.setProperty("meeds.listenerService.enabled", "false");
     // Share ServletContext with Kernel based Services to integrate with Spring
     // Beans
     SpringContext.setServletContext(servletContext);

--- a/deeds-tenant-webapp/src/main/java/io/meeds/tenant/integration/proxy/TenantServiceFacadeImpl.java
+++ b/deeds-tenant-webapp/src/main/java/io/meeds/tenant/integration/proxy/TenantServiceFacadeImpl.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 import io.meeds.deeds.constant.ObjectNotFoundException;
 import io.meeds.deeds.constant.TenantProvisioningStatus;
 import io.meeds.deeds.elasticsearch.model.DeedTenant;
+import io.meeds.deeds.service.ListenerService;
 import io.meeds.deeds.service.TenantService;
 import io.meeds.tenant.integration.SpringIntegration;
 import io.meeds.tenant.integration.service.TenantServiceFacade;
@@ -30,7 +31,10 @@ import io.meeds.tenant.model.DeedTenantHost;
 public class TenantServiceFacadeImpl implements TenantServiceFacade {
 
   @Autowired
-  private TenantService tenantService;
+  private TenantService   tenantService;
+
+  @Autowired
+  private ListenerService listenerService;
 
   @Override
   public DeedTenantHost getDeedTenant(long nftId) {
@@ -63,4 +67,8 @@ public class TenantServiceFacadeImpl implements TenantServiceFacade {
     return tenantService.isDeedManager(address, nftId);
   }
 
+  @Override
+  public void initMetaverseIntegration() {
+    listenerService.enable();
+  }
 }


### PR DESCRIPTION
Prior to this change, when adding Deed Tenant addon into Meeds Package, the Listener Service will automatically search for WoM ES configuration while the property meeds.tenantManagement.nftId isn't configured yet. This change will allow disabling WoM integration when no NFT Id has been set.