### PR TITLE
feat: Use Wallet Mechanism to Send initial funds for Metamask self registered users - MEED-2208

### DIFF
--- a/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListener.java
+++ b/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListener.java
@@ -16,14 +16,11 @@
  */
 package io.meeds.tenant.metamask.listener;
 
-import static org.exoplatform.wallet.utils.WalletUtils.NEW_ADDRESS_ASSOCIATED_EVENT;
-
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.web3j.crypto.WalletUtils;
 
-import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Group;
@@ -54,18 +51,14 @@ public class NewMetamaskCreatedUserListener extends UserEventListener {
 
   private TenantManagerService tenantManagerService;
 
-  private ListenerService      listenerService;
-
   public NewMetamaskCreatedUserListener(IdentityManager identityManager,
                                         OrganizationService organizationService,
                                         WalletAccountService walletAccountService,
-                                        TenantManagerService tenantManagerService,
-                                        ListenerService listenerService) {
+                                        TenantManagerService tenantManagerService) {
     this.organizationService = organizationService;
     this.walletAccountService = walletAccountService;
     this.tenantManagerService = tenantManagerService;
     this.identityManager = identityManager;
-    this.listenerService = listenerService;
   }
 
   @Override
@@ -80,10 +73,7 @@ public class NewMetamaskCreatedUserListener extends UserEventListener {
           + "The used Metamask address will not be associated to current user account.", address, wallet.getTechnicalId());
       return;
     }
-    wallet = createUserWalletByAddress(address);
-    if (wallet != null) {
-      listenerService.broadcast(NEW_ADDRESS_ASSOCIATED_EVENT, wallet.clone(), address);
-    }
+    createUserWalletByAddress(address);
     if (isTenantManager(address)) {
       setTenantManagerRoles(user);
     }

--- a/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListenerTest.java
+++ b/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/listener/NewMetamaskCreatedUserListenerTest.java
@@ -18,9 +18,6 @@ package io.meeds.tenant.metamask.listener;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,7 +27,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.impl.UserImpl;
@@ -39,7 +35,6 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.wallet.model.Wallet;
 import org.exoplatform.wallet.model.WalletProvider;
 import org.exoplatform.wallet.service.WalletAccountService;
-import org.exoplatform.wallet.utils.WalletUtils;
 
 import io.meeds.tenant.service.TenantManagerService;
 
@@ -58,17 +53,13 @@ public class NewMetamaskCreatedUserListenerTest {
   @Mock
   WalletAccountService walletAccountService;
 
-  @Mock
-  ListenerService      listenerService;
-
   @Test
   public void testNewMetamaskCreatedUserListener() throws Exception {
     String username = "0x8714924ADEdB61b790d639F19c3D6F0FE2Cb7576";
     NewMetamaskCreatedUserListener listener = new NewMetamaskCreatedUserListener(identityManager,
                                                                                  organizationService,
                                                                                  walletAccountService,
-                                                                                 tenantManagerService,
-                                                                                 listenerService);
+                                                                                 tenantManagerService);
 
     User user = new UserImpl("not an address");
     listener.postSave(user, true);
@@ -94,11 +85,9 @@ public class NewMetamaskCreatedUserListenerTest {
     when(walletAccountService.saveWallet(any(Wallet.class),
                                          anyBoolean())).thenAnswer(invocation -> invocation.getArgument(0, Wallet.class));
     when(identityManager.getOrCreateUserIdentity(username)).thenReturn(userIdentity);
-    doNothing().when(listenerService).broadcast(anyString(), any(), any());
 
     listener.postSave(user, true);
     verify(walletAccountService, times(1)).saveWallet(any(Wallet.class), anyBoolean());
-    verify(listenerService, times(1)).broadcast(eq(WalletUtils.NEW_ADDRESS_ASSOCIATED_EVENT), any(Wallet.class), eq(username));
   }
 
 }


### PR DESCRIPTION
Prior to this change, the wallet initialization funds was sent explicitely using a trigger to ListenerService. This was a hack until a fix is made in Wallet addons. This change will delete the workaround to be able to benifit from centralized funds initialization made in Wallet.