### PR TITLE
feat: secure Root Access With Metamask Automatically - MEED-3291 - Meeds-io/meeds#1598

### DIFF
--- a/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/service/MetamaskLoginService.java
+++ b/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/service/MetamaskLoginService.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.picketlink.idm.api.SecureRandomProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,17 +76,13 @@ public class MetamaskLoginService {
   private HubService             hubService;
 
   @Setter
-  @Value("${meeds.login.metamask.secureRootAccessWithMetamask:true}")
-  private boolean                secureRootAccessWithMetamask;
-
-  @Setter
   @Value("#{'${meeds.login.metamask.allowedRootAccessWallets:}'.split(',')}")
   private List<String>           allowedRootWallets           = new ArrayList<>();
 
   @PostConstruct
   @ContainerTransactional
   public void init() {
-    if (this.secureRootAccessWithMetamask) {
+    if (CollectionUtils.isNotEmpty(this.allowedRootWallets)) {
       // Avoid allowing to change root password
       accountSetupService.setSkipSetup(true);
       // Generate a new random password for root user
@@ -128,8 +125,7 @@ public class MetamaskLoginService {
    *         allowed to access using root account
    */
   public boolean isSuperUser(String walletAddress) {
-    return secureRootAccessWithMetamask
-           && allowedRootWallets != null
+    return CollectionUtils.isNotEmpty(this.allowedRootWallets)
            && allowedRootWallets.stream().anyMatch(address -> StringUtils.equalsIgnoreCase(address, walletAddress));
   }
 

--- a/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/service/MetamaskLoginServiceTest.java
+++ b/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/service/MetamaskLoginServiceTest.java
@@ -97,13 +97,9 @@ public class MetamaskLoginServiceTest {
 
   @Test
   public void testDontSetRootPasswordOnStartup() {
-    metamaskLoginService.setSecureRootAccessWithMetamask(false);
-    try {
-      metamaskLoginService.init();
-      verifyNoInteractions(organizationService);
-    } finally {
-      metamaskLoginService.setSecureRootAccessWithMetamask(true);
-    }
+    metamaskLoginService.setAllowedRootWallets(Collections.emptyList());
+    metamaskLoginService.init();
+    verifyNoInteractions(organizationService);
   }
 
   @Test
@@ -164,12 +160,7 @@ public class MetamaskLoginServiceTest {
       metamaskLoginService.setAllowedRootWallets(Collections.emptyList());
     }
 
-    metamaskLoginService.setSecureRootAccessWithMetamask(false);
-    try {
-      assertNull(metamaskLoginService.getUserWithWalletAddress(managerAddress));
-    } finally {
-      metamaskLoginService.setSecureRootAccessWithMetamask(true);
-    }
+    assertNull(metamaskLoginService.getUserWithWalletAddress(managerAddress));
 
     User user = mock(User.class);
     whenFindUserByName(managerAddress).thenReturn(user);


### PR DESCRIPTION
Prior to this change, the root password was randomly generated each startup to secure it using an explicit property. This change will allow to secure root password only when another property listing the allowed wallets to access via root isn't empty.