### PR TITLE
feat: Add possibitility to deactivate metamask login by property - EXO-71774

### DIFF
--- a/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/web/MetamaskLoginExtension.java
+++ b/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/web/MetamaskLoginExtension.java
@@ -38,13 +38,8 @@ public class MetamaskLoginExtension extends BaseMetamaskExtension {
 
   private static final String            METAMASK_LOGIN = "metamaskLogin";
 
-  protected            ExoFeatureService exoFeatureService;
-
   @Autowired
-  public MetamaskLoginExtension(ExoFeatureService exoFeatureService) {
-    super();
-    this.exoFeatureService = exoFeatureService;
-  }
+  protected            ExoFeatureService exoFeatureService;
 
   @Override
   public List<String> getExtensionNames() {

--- a/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/web/MetamaskLoginExtension.java
+++ b/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/web/MetamaskLoginExtension.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.exoplatform.commons.api.settings.ExoFeatureService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import org.exoplatform.web.ControllerContext;
@@ -34,6 +36,16 @@ import jakarta.servlet.http.HttpSession;
 @Service
 public class MetamaskLoginExtension extends BaseMetamaskExtension {
 
+  private static final String            METAMASK_LOGIN = "metamaskLogin";
+
+  protected            ExoFeatureService exoFeatureService;
+
+  @Autowired
+  public MetamaskLoginExtension(ExoFeatureService exoFeatureService) {
+    super();
+    this.exoFeatureService = exoFeatureService;
+  }
+
   @Override
   public List<String> getExtensionNames() {
     return Collections.singletonList(LoginHandler.LOGIN_EXTENSION_NAME);
@@ -42,7 +54,7 @@ public class MetamaskLoginExtension extends BaseMetamaskExtension {
   @Override
   public Map<String, Object> extendParameters(ControllerContext controllerContext, String extensionName) {
     Map<String, Object> params = new HashMap<>();
-    params.put("metamaskEnabled", true);
+    params.put("metamaskEnabled", exoFeatureService.isActiveFeature(METAMASK_LOGIN));
 
     HttpSession httpSession = controllerContext.getRequest().getSession(true);
     params.put("rawMessage", metamaskLoginService.generateLoginMessage(httpSession));

--- a/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/web/MetamaskLoginExtensionTest.java
+++ b/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/web/MetamaskLoginExtensionTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.Map;
 
+import org.exoplatform.commons.api.settings.ExoFeatureService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,6 +49,9 @@ class MetamaskLoginExtensionTest {
   private MetamaskLoginService   metamaskLoginService;
 
   @MockBean
+  private ExoFeatureService exoFeatureService;
+
+  @MockBean
   private HubService             hubService;
 
   @Autowired
@@ -68,6 +72,7 @@ class MetamaskLoginExtensionTest {
     HttpSession session = mock(HttpSession.class);
     when(controllerContext.getRequest()).thenReturn(request);
     when(request.getSession(anyBoolean())).thenReturn(session);
+    when(exoFeatureService.isActiveFeature("metamaskLogin")).thenReturn(true);
     when(metamaskLoginService.generateLoginMessage(session)).thenReturn(rawMessage);
 
     Map<String, Object> extendParameters = metamaskLoginExtension.extendParameters(controllerContext, null);
@@ -76,4 +81,21 @@ class MetamaskLoginExtensionTest {
     assertEquals(rawMessage, extendParameters.get("rawMessage"));
   }
 
+  @Test
+  void testDisableExtension () {
+    String rawMessage = "rawMessage";
+
+    ControllerContext controllerContext = mock(ControllerContext.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    when(controllerContext.getRequest()).thenReturn(request);
+    when(request.getSession(anyBoolean())).thenReturn(session);
+    when(metamaskLoginService.generateLoginMessage(session)).thenReturn(rawMessage);
+    when(exoFeatureService.isActiveFeature("metamaskLogin")).thenReturn(false);
+
+    Map<String, Object> extendParameters = metamaskLoginExtension.extendParameters(controllerContext, null);
+    assertNotNull(extendParameters);
+    assertEquals(false, extendParameters.get("metamaskEnabled"));
+
+  }
 }


### PR DESCRIPTION
Before this fix, it was nto possible to deactivate metamask login button on login page This commit add the possibility to set property exo.feature.metamaskLogin.enabled to false to deactivate it.

Resolves meeds-io/meeds#1992