### PR TITLE
fix : Remove warning during server startup - EXO-74326

### DIFF
--- a/deeds-tenant-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/deeds-tenant-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -233,6 +233,7 @@
   <module>
     <name>ethers</name>
     <script>
+      <minify>false</minify>
       <path>/js/ethers.umd.min.js</path>
     </script>
   </module>


### PR DESCRIPTION
Before this fix, there is a warning during server startup on file ethers.js This is because we try to minify it in gatein-resources but it is already minified. This commit add the option to not minify this js

Resolves meeds-io/meeds#2412