### PR TITLE
change url in text above Metamask Start button

### DIFF
--- a/deeds-tenant-webapp/src/main/webapp/vue-app/wom-setup-admin/components/connection/form/DeedManagerSelector.vue
+++ b/deeds-tenant-webapp/src/main/webapp/vue-app/wom-setup-admin/components/connection/form/DeedManagerSelector.vue
@@ -49,7 +49,7 @@ export default {
   computed: {
     signMessageTitle() {
       return this.$t('wom.signMessageTitle', {
-        0: '<a href="https://www.meeds.io/marketplace" target="_blank">',
+        0: '<a href="https://www.meeds.io" target="_blank">',
         1: '</a>',
       });
     },


### PR DESCRIPTION
Before this change, the info text had a direct link to the marketplace. 

After this change the url is changed to the more generic url : https://www.meeds.io

Fixes Meeds-io/meeds#2659