### PR TITLE
fix: Translations for metamask button are not displayed - meeds-io/MIPs#203 - MEED-9523

### DIFF
--- a/deeds-tenant-webapp/src/main/webapp/vue-app/login/components/LoginMetamask.vue
+++ b/deeds-tenant-webapp/src/main/webapp/vue-app/login/components/LoginMetamask.vue
@@ -27,7 +27,9 @@
       :display-text="displayText"
       :is="isMenu && 'portal-login-provider-menu-link' || 'portal-login-provider-link'"
       :class="isMenu && 'portal-login-provider-menu-link' || 'portal-login-provider-link'"
-      @submit="signInWithMetamask()" />
+      @submit="signInWithMetamask()"
+      :translation-identifier="translationIdentifier"
+      :display-providers-icons="displayProvidersIcons"/>
     <form
       ref="metamaskLoginForm"
       action="/portal/login"
@@ -74,6 +76,14 @@ export default {
     isMenu: {
       type: Boolean,
       default: false,
+    },
+    translationIdentifier: {
+      type: String,
+      default: '',
+    },
+    displayProvidersIcons: {
+      type: Boolean,
+      default: true,
     },
   },
   data: () => ({


### PR DESCRIPTION
Before this fix, after settings translations for metamask button, the translations are not displayed.

This commit update the LoginMetamask component to use the translationIdentifier when present