### PR TITLE
fix : Unify UI of external providers with sign-in button - MEED-9763 - meeds-io/MIPs#203

### DIFF
--- a/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/web/MetamaskRegisterExtension.java
+++ b/deeds-tenant-service/src/main/java/io/meeds/tenant/metamask/web/MetamaskRegisterExtension.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.api.settings.ExoFeatureService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import org.exoplatform.web.ControllerContext;
@@ -38,6 +40,9 @@ public class MetamaskRegisterExtension extends BaseMetamaskExtension {
 
   public static final String METAMASK_REGISTRATION_ENABLED = "metamaskRegistrationEnabled";
 
+  @Autowired
+  protected            ExoFeatureService exoFeatureService;
+
   @Override
   public List<String> getExtensionNames() {
     return Arrays.asList(RegisterHandler.REGISTER_EXTENSION_NAME, LoginHandler.LOGIN_EXTENSION_NAME);
@@ -46,7 +51,7 @@ public class MetamaskRegisterExtension extends BaseMetamaskExtension {
   @Override
   public Map<String, Object> extendParameters(ControllerContext controllerContext, String extensionName) {
     Map<String, Object> params = new HashMap<>();
-    if (metamaskLoginService.isAllowUserRegistration()) {
+    if (exoFeatureService.isActiveFeature("metamaskLogin") && metamaskLoginService.isAllowUserRegistration()) {
       if (StringUtils.equals(LoginHandler.LOGIN_EXTENSION_NAME, extensionName)) {
         params.put(RegisterHandler.REGISTER_ENABLED, true);
       } else if (StringUtils.equals(RegisterHandler.REGISTER_EXTENSION_NAME, extensionName)) {

--- a/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/web/MetamaskRegisterExtensionTest.java
+++ b/deeds-tenant-service/src/test/java/io/meeds/tenant/metamask/web/MetamaskRegisterExtensionTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.exoplatform.commons.api.settings.ExoFeatureService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -49,7 +50,10 @@ class MetamaskRegisterExtensionTest {
   private MetamaskLoginService      metamaskLoginService;
 
   @MockBean
-  private HubService                hubService;
+  private ExoFeatureService exoFeatureService;
+
+  @MockBean
+  private HubService        hubService;
 
   @Autowired
   private MetamaskRegisterExtension metamaskRegisterExtension;
@@ -64,6 +68,8 @@ class MetamaskRegisterExtensionTest {
   @Test
   void testExtendParametersForLogin() {
     when(metamaskLoginService.isAllowUserRegistration()).thenReturn(true);
+    when(exoFeatureService.isActiveFeature("metamaskLogin")).thenReturn(true);
+
     Map<String, Object> extendParameters = metamaskRegisterExtension.extendParameters(null, LoginHandler.LOGIN_EXTENSION_NAME);
     assertNotNull(extendParameters);
     assertEquals(true, extendParameters.get(RegisterHandler.REGISTER_ENABLED));
@@ -79,7 +85,10 @@ class MetamaskRegisterExtensionTest {
   void testExtendParametersForRegister() {
     String rawMessage = "rawMessage";
 
+
     when(metamaskLoginService.isAllowUserRegistration()).thenReturn(true);
+    when(exoFeatureService.isActiveFeature("metamaskLogin")).thenReturn(true);
+
     ControllerContext controllerContext = mock(ControllerContext.class);
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpSession session = mock(HttpSession.class);

--- a/deeds-tenant-webapp/src/main/webapp/vue-app/register-extension/components/MetamaskRegister.vue
+++ b/deeds-tenant-webapp/src/main/webapp/vue-app/register-extension/components/MetamaskRegister.vue
@@ -29,8 +29,9 @@
       :class="!isDeedTenant && 'rounded-lg'"
       target="_blank"
       rel="noreferrer"
-      class="mx-auto white-background d-block max-width-fit btn"
-      outlined>
+      class="mx-auto white-background d-block max-width-fit"
+      outlined
+      style="background-color:white;">
       <v-img
         src="/deeds-tenant/images/metamask.svg"
         max-height="25px"
@@ -43,9 +44,10 @@
       :color="isDeedTenant && 'primary'"
       :large="isDeedTenant"
       :class="!isDeedTenant && 'rounded-lg'"
-      class="mx-auto white-background d-block max-width-fit btn"
+      class="mx-auto white-background d-block max-width-fit"
       outlined
-      @click="signInWithMetamask()">
+      @click="signInWithMetamask()"
+      style="background-color:white;">
       <v-img
         src="/deeds-tenant/images/metamask.svg"
         max-height="25px"


### PR DESCRIPTION
External login providers buttons have different UI from other button on login page This commit ensure to unify it.
In addition, this commit fix a collateral problem : when metamask feature is deactivated, the metamask button on register page was present