### PR TITLE
feat: Improve Log Verbosity when Blockchain Connection Fails

### DIFF
--- a/deeds-tenant-service/src/main/java/io/meeds/tenant/hub/scheduling/task/HubPeriodicUpdateJob.java
+++ b/deeds-tenant-service/src/main/java/io/meeds/tenant/hub/scheduling/task/HubPeriodicUpdateJob.java
@@ -35,10 +35,12 @@ import io.meeds.tenant.hub.service.HubService;
 @Component
 public class HubPeriodicUpdateJob {
 
-  private static final Log LOG = ExoLogger.getLogger(HubPeriodicUpdateJob.class);
+  private static final Log LOG         = ExoLogger.getLogger(HubPeriodicUpdateJob.class);
 
   @Autowired
   private HubService       hubService;
+
+  private int              errorsCount = 0;
 
   @Scheduled(cron = "${meeds.deed.tenant.cron:0 0/2 * * * *}")
   @ContainerTransactional
@@ -46,7 +48,16 @@ public class HubPeriodicUpdateJob {
     try {
       hubService.updateHubCard();
     } catch (Exception e) {
-      LOG.warn("Error while updating Hub Card", e);
+      if (errorsCount == 0) {
+        LOG.warn("Error while updating Hub Card", e);
+      } else if (errorsCount < 10) {
+        LOG.warn("Error while updating Hub Card: {}", e.getMessage());
+      } else if (errorsCount == 10) {
+        LOG.warn("Error while updating Hub Card (Log level will be switched to debug): {}", e.getMessage());
+      } else {
+        LOG.debug("Error while updating Hub Card: {}", e.getMessage());
+      }
+      errorsCount++;
     }
   }
 


### PR DESCRIPTION
Prior to this change, when a Blockchain connection error happens during Server Runtime, the Scheduled Jobs will continue to log ERROR Level which pollutes Server Logs. This change will avoid this by changing the Log Level switch number of connection errors.